### PR TITLE
split '--env' and its argument to two appendWslArg calls

### DIFF
--- a/hvpty/hvpty-backend.cpp
+++ b/hvpty/hvpty-backend.cpp
@@ -99,6 +99,8 @@ static void usage(const char *prog)
     "\n"
     "Options:\n"
     "  -c, --cols N   Set N columns for pty\n"
+    "  -e VAR         Copies VAR into the WSL environment.\n"
+    "  -e VAR=VAL     Sets VAR to VAL in the WSL environment.\n"
     "  -h, --help     Show this usage information\n"
     "  -l, --login    Start a login shell\n"
     "  -P, --path dir Start in certain path\n"
@@ -137,11 +139,11 @@ int main(int argc, char *argv[])
     const char shortopts[] = "+c:e:hlp:P:r:";
     const struct option longopts[] = {
         { "cols",  required_argument, 0, 'c' },
+        { "env",   required_argument, 0, 'e' },
         { "help",  no_argument,       0, 'h' },
         { "login", no_argument,       0, 'l' },
         { "port",  required_argument, 0, 'p' },
         { "path",  required_argument, 0, 'P' },
-	{ "env",   required_argument, 0, 'e' },
         { "rows",  required_argument, 0, 'r' },
         { 0,       no_argument,       0,  0  },
     };

--- a/hvpty/hvpty-backend.cpp
+++ b/hvpty/hvpty-backend.cpp
@@ -141,6 +141,7 @@ int main(int argc, char *argv[])
         { "login", no_argument,       0, 'l' },
         { "port",  required_argument, 0, 'p' },
         { "path",  required_argument, 0, 'P' },
+	{ "env",   required_argument, 0, 'e' },
         { "rows",  required_argument, 0, 'r' },
         { 0,       no_argument,       0,  0  },
     };

--- a/hvpty/hvpty.cpp
+++ b/hvpty/hvpty.cpp
@@ -243,6 +243,7 @@ int main(int argc, char *argv[])
     const struct option longopts[] = {
         { "backend",       required_argument, 0, 'b' },
         { "distribution",  required_argument, 0, 'd' },
+        { "env",           required_argument, 0, 'e' },
         { "help",          no_argument,       0, 'h' },
         { "login",         no_argument,       0, 'l' },
         { "no-login",      no_argument,       0, 'L' },

--- a/hvpty/hvpty.cpp
+++ b/hvpty/hvpty.cpp
@@ -350,8 +350,10 @@ int main(int argc, char *argv[])
     wslCmdLine.append(L")\"");
 
     for (const auto &envPair : env.pairs())
-        appendWslArg(wslCmdLine, L"--env" + envPair.first + L"=" + envPair.second);
-
+    {
+        appendWslArg(wslCmdLine, L"--env");
+        appendWslArg(wslCmdLine, envPair.first + L"=" + envPair.second);
+    }
     if (loginMode == LoginMode::Yes)
         appendWslArg(wslCmdLine, L"--login");
 


### PR DESCRIPTION
I see the latest release of wsltty is not working with WSL2 distros. After a little tracing, I find that `sh` will pass arguments to one `argv` if it is quoted. Thus using '--env "x=y"' or '--env x=y' will be recognized as one argument and the `getopt_long` cannot process it in `hvpty_backend`.
So I split it to two `appendWslArg` calls.
Also, the backend has not the `env` long option, I'm not sure why it works when I pass `--env` to it.
