### PR TITLE
Use wordexp to process wsldir so that ~ and $ENVVAR is better handled

### DIFF
--- a/hvpty/hvpty-backend.cpp
+++ b/hvpty/hvpty-backend.cpp
@@ -293,7 +293,8 @@ int main(int argc, char *argv[])
         /* Changed directory should affect in child process */
         if (!childParams.cwd.empty())
         {
-            wordexp_t p;    wordexp(childParams.cwd.c_str(), &p, 0);
+            wordexp_t p;
+            wordexp(childParams.cwd.c_str(), &p, 0);
             if (p.we_wordc != 1) {
                 fprintf(stderr, "path expandsion failed, word expanded to %ld paths", p.we_wordc);
             }

--- a/hvpty/hvpty-backend.cpp
+++ b/hvpty/hvpty-backend.cpp
@@ -20,6 +20,7 @@
 #include <sys/wait.h>
 #include <termios.h>
 #include <unistd.h>
+#include <wordexp.h>
 
 #include <linux/vm_sockets.h>
 
@@ -292,7 +293,12 @@ int main(int argc, char *argv[])
         /* Changed directory should affect in child process */
         if (!childParams.cwd.empty())
         {
-            res = chdir(childParams.cwd.c_str());
+            wordexp_t p;    wordexp(childParams.cwd.c_str(), &p, 0);
+            if (p.we_wordc != 1) {
+                fprintf(stderr, "path expandsion failed, word expanded to %ld paths", p.we_wordc);
+            }
+            res = chdir(p.we_wordv[0]);
+            wordfree(&p);
             if (res != 0)
                 perror("chdir");
         }

--- a/hvpty/hvpty-backend.cpp
+++ b/hvpty/hvpty-backend.cpp
@@ -293,13 +293,13 @@ int main(int argc, char *argv[])
         /* Changed directory should affect in child process */
         if (!childParams.cwd.empty())
         {
-            wordexp_t p;
-            wordexp(childParams.cwd.c_str(), &p, 0);
-            if (p.we_wordc != 1) {
-                fprintf(stderr, "path expandsion failed, word expanded to %ld paths", p.we_wordc);
+            wordexp_t expanded_cwd;
+            wordexp(childParams.cwd.c_str(), &expanded_cwd, 0);
+            if (expanded_cwd.we_wordc != 1) {
+                fprintf(stderr, "path expandsion failed, word expanded to %ld paths", expanded_cwd.we_wordc);
             }
-            res = chdir(p.we_wordv[0]);
-            wordfree(&p);
+            res = chdir(expanded_cwd.we_wordv[0]);
+            wordfree(&expanded_cwd);
             if (res != 0)
                 perror("chdir");
         }


### PR DESCRIPTION
I find wsltty passed `--wsldir ~` to hvpty, while the backend takes `~` as an argument so that the `~` is not properly processed to an expanded path, I use the `wordexp` which can expand `~` to home directory and also expands environment variables.