### PR TITLE
wslbridge2.cpp: Add additional entropy to srand

### DIFF
--- a/src/wslbridge2.cpp
+++ b/src/wslbridge2.cpp
@@ -177,7 +177,12 @@ int main(int argc, char *argv[])
     GetIp();
 
     /* Set time as seed for generation of random port */
-    srand(time(NULL));
+    struct timeval tv;
+    gettimeofday(&tv, NULL);
+    
+    long seed = tv.tv_usec << 16 | (getpid() & 0xFFFF);    
+    
+    srand(seed);
 
     int ret;
     const char shortopts[] = "+b:d:e:hlu:w:W:V:x";


### PR DESCRIPTION
Adds additional entropy to srand in wslbridge2.cpp. Corrects an issue where if multiple instances are created within the same second the will have the same seed, which will cause them to be attempt to allocate the same ephemeral ports in WindowsSock.cpp/ListenHvSock(). The issue was observed when created multiple WSL terminals via tasks in ConEmu.

This fix increases the entropy delivered to srand by using microseconds combined with the current pid rather than seconds. This ensures that the subsequent call to rand will produce different output.