### PR TITLE
Add xonsh command syntax to work with xonsh as the default shell

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ WSL distribution. Here are the list of valid options:
 * `-h` or `--help`: Show this usage information.
 * `-l` or `--login`: Start a login shell in WSL.
 * `-s` or `--show`: Shows hidden backend window and debug output.
+* `-p` or `--python`: Translates command line syntax from sh to Python (use when xonsh is the default shell)
 * `-u` or `--user`: Run as the specified user in WSL.
 * `-w` or `--windir`: Changes the working directory to a Windows path.
 * `-W` or `--wsldir`: Changes the working directory to WSL path.

--- a/src/common.hpp
+++ b/src/common.hpp
@@ -7,7 +7,7 @@
 #ifndef COMMON_HPP
 #define COMMON_HPP
 
-#define WSLBRIDGE2_VERSION v0.8
+#define WSLBRIDGE2_VERSION v0.9
 
 #define XSTRINGIFY(x) #x
 #define STRINGIFY(x) XSTRINGIFY(x)

--- a/src/wslbridge2.cpp
+++ b/src/wslbridge2.cpp
@@ -126,6 +126,8 @@ static void usage(const char *prog)
     printf("  -h, --help    Show this usage information.\n");
     printf("  -l, --login   Start a login shell.\n");
     printf("  -s, --show    Shows hidden backend window and debug output.\n");
+    printf("  -p, --python  Translate command line syntax from sh to Python\n");
+    printf("                Use when xonsh is the default shell (overrides auto detection).\n");
     printf("  -u, --user    WSL User Name\n");
     printf("                Run as the specified user.\n");
     printf("  -w, --windir  Folder\n");
@@ -165,7 +167,7 @@ int main(int argc, char *argv[])
     }
 
     int ret;
-    const char shortopts[] = "+b:d:e:hlsu:V:w:W:x";
+    const char shortopts[] = "+b:d:e:hlsup:V:w:W:x";
     const struct option longopts[] = {
         { "backend",       required_argument, 0, 'b' },
         { "distribution",  required_argument, 0, 'd' },
@@ -174,6 +176,7 @@ int main(int argc, char *argv[])
         { "login",         no_argument,       0, 'l' },
         { "show",          required_argument, 0, 's' },
         { "user",          required_argument, 0, 'u' },
+        { "python",        required_argument, 0, 'p' },
         { "wslver",        required_argument, 0, 'V' },
         { "windir",        required_argument, 0, 'w' },
         { "wsldir",        required_argument, 0, 'W' },
@@ -185,7 +188,7 @@ int main(int argc, char *argv[])
     class TerminalState termState;
     std::string distroName, customBackendPath;
     std::string winDir, wslDir, userName;
-    volatile bool debugMode = false, loginMode = false, xservMode = false;
+    volatile bool debugMode = false, loginMode = false, xservMode = false, pythonMode = false;
 
     if (argv[0][0] == '-')
         loginMode = true;
@@ -230,6 +233,8 @@ int main(int argc, char *argv[])
             case 'h': usage(argv[0]); break;
             case 'l': loginMode = true; break;
             case 's': debugMode = true; break;
+
+            case 'p': pythonMode = true; break;
 
             case 'u':
                 userName = optarg;

--- a/src/wslbridge2.cpp
+++ b/src/wslbridge2.cpp
@@ -690,7 +690,7 @@ int main(int argc, char *argv[])
     ret = pthread_create(&tidInput, nullptr, send_buffer, nullptr);
     assert(ret == 0);
 
-    /* Create thread to send input buffer to input socket */
+    /* Create thread to send output buffer to output socket */
     pthread_t tidOutput;
     ret = pthread_create(&tidOutput, nullptr, receive_buffer, nullptr);
     assert(ret == 0);


### PR DESCRIPTION
I've added a new Python command syntax that can be understood by the Python-based `xonsh` shell, which is required when xonsh is used as the default shell since it chokes on the current `sh`-based syntax:
- via a `-p`/`--python` command line argument (but then this breaks other default shells, so inconvenient if you switch default shells)
- via an auto-detection feature (which runs a `grep "^$(id -un)": /etc/passwd` to get the default shell before launching the relevant command) — I've copied your main process creation code and just removed the parts that weren't needed (sockets etc.), so it's a bit of a code duplication

For the new syntax I bypassed the `appendWslArg` function as there is no need to escape the quotes, and I don't understand how relevant the other corrections are (and how to adjust them properly for the new syntax) :)

Only tested this with `ConEmu` and `msys2`

Fixes: #31