### PR TITLE
Get vm id from wslhost.exe command line

### DIFF
--- a/src/GetVmId.cpp
+++ b/src/GetVmId.cpp
@@ -16,6 +16,7 @@
 #include "GetVmId.hpp"
 #include "LxssUserSession.hpp"
 #include "Helpers.hpp"
+#include "GetVmIdWsl2.hpp"
 
 #ifndef WSL_DISTRIBUTION_FLAGS_VALID
 
@@ -309,7 +310,15 @@ HRESULT GetVmId(GUID *DistroId, GUID *LxInstanceID, const int LiftedWSLVersion)
 
         if (hRes)
         {
-            LOG_HRESULT_ERROR("CreateLxProcess", hRes);
+            // Try get VM ID from command line of wslHost.exe
+            if (GetVmIdWsl2(LxInstanceID))
+            {
+                hRes = 0;
+            }
+            else
+            {
+                LOG_HRESULT_ERROR("CreateLxProcess", hRes);
+            }
         }
     }
     else if (WindowsBuild < 20211) // Before Build 20211 Fe

--- a/src/GetVmIdWsl2.cpp
+++ b/src/GetVmIdWsl2.cpp
@@ -1,0 +1,126 @@
+#include <combaseapi.h>
+#include <Windows.h>
+#include <TlHelp32.h>
+#include <winternl.h>
+#include <ntstatus.h>
+#include <psapi.h>
+#include <vector>
+#include <string>
+
+#include "common.hpp"
+#include "GetVmIdWsl2.hpp"
+
+bool ExtractGUID(const std::wstring key, const std::wstring& commandLine, std::wstring& guid) {
+    size_t pos = commandLine.find(key);
+    if (pos != std::wstring::npos) 
+    {
+        size_t start = commandLine.find(L'{', pos);
+        size_t end = commandLine.find(L'}', start);
+        if (start != std::wstring::npos && end != std::wstring::npos) 
+        {
+            guid = commandLine.substr(start, end - start + 1);
+            return true;
+        }
+    }
+    return false;
+}
+
+bool GetCommandLineForPID(DWORD pid, std::wstring& commandLine)
+{
+    HMODULE hNtdll = GetModuleHandle(L"ntdll.dll");
+    using NtQueryInformationProcessFunc = NTSTATUS(NTAPI*)(HANDLE, PROCESSINFOCLASS, PVOID, ULONG, PULONG);
+    NtQueryInformationProcessFunc NtQueryInformationProcess = (NtQueryInformationProcessFunc)GetProcAddress(hNtdll, "NtQueryInformationProcess");
+
+    if (!NtQueryInformationProcess) 
+        return false;
+
+    // Open a handle to the process
+    HANDLE process = OpenProcess(PROCESS_QUERY_INFORMATION | PROCESS_VM_READ, FALSE, pid);
+    if (process == NULL)
+    {
+        DWORD err = GetLastError();
+        fatal("failed to open the process, error: %d", err);
+        return false;
+    }
+    // Get the address of the PEB
+    PROCESS_BASIC_INFORMATION pbi = {};
+    NTSTATUS status = NtQueryInformationProcess(process, ProcessBasicInformation, &pbi, sizeof(pbi), NULL);
+    if (status != STATUS_SUCCESS)
+    {
+        CloseHandle(process);
+        fatal("failed to query the process, error: %d", status);
+        return false;
+    }
+    // Get the address of the process parameters in the PEB
+    PEB peb = {};
+    if (!ReadProcessMemory(process, pbi.PebBaseAddress, &peb, sizeof(peb), NULL))
+    {
+        CloseHandle(process);
+        DWORD err = GetLastError();
+        fatal("failed to read the process PEB, error: %d", err);
+        return false;
+    }
+    // Get the command line arguments from the process parameters
+    RTL_USER_PROCESS_PARAMETERS params = {};
+    if (!ReadProcessMemory(process, peb.ProcessParameters, &params, sizeof(params), NULL))
+    {
+        CloseHandle(process);
+        DWORD err = GetLastError();
+        fatal("failed to read the process params, error: %d", err);
+        return false;
+    }
+    UNICODE_STRING &commandLineArgs = params.CommandLine;
+    std::vector<WCHAR> buffer(commandLineArgs.Length / sizeof(WCHAR));
+    if (!ReadProcessMemory(process, commandLineArgs.Buffer, buffer.data(), commandLineArgs.Length, NULL))
+    {
+        CloseHandle(process);
+        DWORD err = GetLastError();
+        fatal("failed to read the process command line, error: %d", err);
+        return false;
+    }
+
+    CloseHandle(process);
+    commandLine.assign(buffer.data(), buffer.size());
+    return true;
+}
+
+std::vector<DWORD> GetProcessIDsByName(const std::wstring& processName) {
+    std::vector<DWORD> processIDs;
+    HANDLE hProcessSnap = CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0);
+    PROCESSENTRY32 pe32;
+    pe32.dwSize = sizeof(PROCESSENTRY32);
+
+    if (Process32First(hProcessSnap, &pe32)) 
+    {
+        do 
+        {
+            if (pe32.szExeFile == processName) 
+            {
+                processIDs.push_back(pe32.th32ProcessID);
+            }
+        } while (Process32Next(hProcessSnap, &pe32));
+    }
+    CloseHandle(hProcessSnap);
+    return processIDs;
+}
+
+// Extract GUID from wslHost.exe command line
+// Example commandline:
+// wslhost.exe --vm-id {f6446e02-236e-4b24-9916-2d4ad9a1096f} --handle 1664
+bool GetVmIdWsl2(GUID& vmId) {
+    std::vector<DWORD>  pids = GetProcessIDsByName(L"wslhost.exe");
+    for (DWORD pid : pids) {
+        std::wstring cmdLine;
+        if (!GetCommandLineForPID(pid, cmdLine))
+            continue;
+
+        std::wstring cmdVmId;
+        if(!ExtractGUID(L"--vm-id", cmdLine, cmdVmId)) 
+            continue;
+        
+        if (IIDFromString(cmdVmId.c_str(), &vmId) == S_OK) 
+            return true;
+    }
+    return false;
+}
+

--- a/src/GetVmIdWsl2.cpp
+++ b/src/GetVmIdWsl2.cpp
@@ -107,7 +107,7 @@ std::vector<DWORD> GetProcessIDsByName(const std::wstring& processName) {
 // Extract GUID from wslHost.exe command line
 // Example commandline:
 // wslhost.exe --vm-id {f6446e02-236e-4b24-9916-2d4ad9a1096f} --handle 1664
-bool GetVmIdWsl2(GUID& vmId) {
+bool GetVmIdWsl2(GUID* vmId) {
     std::vector<DWORD>  pids = GetProcessIDsByName(L"wslhost.exe");
     for (DWORD pid : pids) {
         std::wstring cmdLine;
@@ -115,10 +115,10 @@ bool GetVmIdWsl2(GUID& vmId) {
             continue;
 
         std::wstring cmdVmId;
-        if(!ExtractGUID(L"--vm-id", cmdLine, cmdVmId)) 
+        if(!ExtractGUID(L"--vm-id", cmdLine, cmdVmId))
             continue;
         
-        if (IIDFromString(cmdVmId.c_str(), &vmId) == S_OK) 
+        if (IIDFromString(cmdVmId.c_str(), vmId) == S_OK) 
             return true;
     }
     return false;

--- a/src/GetVmIdWsl2.hpp
+++ b/src/GetVmIdWsl2.hpp
@@ -1,0 +1,8 @@
+#include <Windows.h>
+
+#ifndef VMIDWSL2_HPP
+#define VMIDWSL2_HPP
+
+bool GetVmIdWsl2(GUID& vmId);
+
+#endif /* VMIDWSL2_HPP */

--- a/src/GetVmIdWsl2.hpp
+++ b/src/GetVmIdWsl2.hpp
@@ -3,6 +3,6 @@
 #ifndef VMIDWSL2_HPP
 #define VMIDWSL2_HPP
 
-bool GetVmIdWsl2(GUID& vmId);
+bool GetVmIdWsl2(GUID* vmId);
 
 #endif /* VMIDWSL2_HPP */

--- a/src/Makefile.frontend
+++ b/src/Makefile.frontend
@@ -22,6 +22,7 @@ LIBS = -lole32 -lws2_32
 OBJS = \
 $(BINDIR)/common.obj \
 $(BINDIR)/GetVmId.obj \
+$(BINDIR)/GetVmIdWsl2.obj \
 $(BINDIR)/Helpers.obj \
 $(BINDIR)/TerminalState.obj \
 $(BINDIR)/windows-sock.obj \
@@ -51,6 +52,9 @@ $(BINDIR)/windows-sock.obj : windows-sock.c
 	$(CC) -c $(CFLAGS) $< -o $@
 
 $(BINDIR)/wslbridge2.obj : wslbridge2.cpp
+	$(CXX) -c $(CXXFLAGS) $(CCOPT) $< -o $@
+
+$(BINDIR)/GetVmIdWsl2.obj : GetVmIdWsl2.cpp
 	$(CXX) -c $(CXXFLAGS) $(CCOPT) $< -o $@
 
 $(BINDIR) :

--- a/src/wslbridge2.cpp
+++ b/src/wslbridge2.cpp
@@ -27,6 +27,7 @@
 #include "Environment.hpp"
 #include "TerminalState.hpp"
 #include "windows-sock.h"
+#include "GetVmIdWsl2.hpp"
 
 union IoSockets
 {
@@ -384,12 +385,12 @@ int main(int argc, char *argv[])
     {
         // wsltty#302: Start dummy process after ComInit, otherwise RPC_E_TOO_LATE.
         // wslbridge2#38: Do this only for WSL2 as WSL1 does not need the VM context.
+        // wslbridge2#42: Required for WSL2 to get the VM ID.
         if (LiftedWSLVersion)
             start_dummy(wslPath, wslCmdLine, distroName, debugMode);
 
-        const HRESULT hRes = GetVmId(&DistroId, &VmId, LiftedWSLVersion);
-        if (hRes != 0)
-            fatal("GetVmId: %s\n", GetErrorMessage(hRes).c_str());
+        if (!GetVmIdWsl2(VmId))
+            fatal("Failed to get VM ID");
 
         inputSock = win_vsock_create();
         outputSock = win_vsock_create();

--- a/src/wslbridge2.cpp
+++ b/src/wslbridge2.cpp
@@ -27,7 +27,6 @@
 #include "Environment.hpp"
 #include "TerminalState.hpp"
 #include "windows-sock.h"
-#include "GetVmIdWsl2.hpp"
 
 union IoSockets
 {
@@ -389,8 +388,9 @@ int main(int argc, char *argv[])
         if (LiftedWSLVersion)
             start_dummy(wslPath, wslCmdLine, distroName, debugMode);
 
-        if (!GetVmIdWsl2(VmId))
-            fatal("Failed to get VM ID");
+        const HRESULT hRes = GetVmId(&DistroId, &VmId, LiftedWSLVersion);
+        if (hRes != 0)
+            fatal("GetVmId: %s\n", GetErrorMessage(hRes).c_str());
 
         inputSock = win_vsock_create();
         outputSock = win_vsock_create();


### PR DESCRIPTION
Lookup VM ID for WSL 2 instances by looking at the command line arguments for wslhost.exe

fixes #42 

Tested on WSL version:
WSL version: 2.3.24.0
Kernel version: 5.15.153.1-2
WSLg version: 1.0.65
MSRDC version: 1.2.5620
Direct3D version: 1.611.1-81528511
DXCore version: 10.0.26100.1-240331-1435.ge-release
Windows version: 10.0.22631.4169
