### PR TITLE
Fixed wrong size of `struct winsize`.

### DIFF
--- a/src/wslbridge2-backend.cpp
+++ b/src/wslbridge2-backend.cpp
@@ -256,9 +256,9 @@ int main(int argc, char *argv[])
                             s++;
                             len--;
                             // ensure 8 more bytes are loaded for winsize
-                            while (readRet > 0 && len < 16)
+                            while (readRet > 0 && len < 8)
                             {
-                                readRet = recv(ioSockets.inputSock, s + len, 16 - len, 0);
+                                readRet = recv(ioSockets.inputSock, s + len, 8 - len, 0);
                                 if (readRet > 0)
                                 {
                                     len += readRet;


### PR DESCRIPTION
See: https://github.com/Biswa96/wslbridge2/pull/45#issuecomment-2506776730

> struct winsize is 8 bytes long, it is wrong to read 16 bytes from the socket. That's why the backend blocks until you feed in 8 more bytes by hitting keys.

I fixed it.