### PR TITLE
Fix for retrieving command line arguments of wslhost.exe.

### DIFF
--- a/src/GetVmId.cpp
+++ b/src/GetVmId.cpp
@@ -16,7 +16,6 @@
 #include "GetVmId.hpp"
 #include "LxssUserSession.hpp"
 #include "Helpers.hpp"
-#include "GetVmIdWsl2.hpp"
 
 #ifndef WSL_DISTRIBUTION_FLAGS_VALID
 
@@ -310,15 +309,7 @@ HRESULT GetVmId(GUID *DistroId, GUID *LxInstanceID, const int LiftedWSLVersion)
 
         if (hRes)
         {
-            // Try get VM ID from command line of wslHost.exe
-            if (GetVmIdWsl2(LxInstanceID))
-            {
-                hRes = 0;
-            }
-            else
-            {
-                LOG_HRESULT_ERROR("CreateLxProcess", hRes);
-            }
+            // LOG_HRESULT_ERROR("CreateLxProcess", hRes);
         }
     }
     else if (WindowsBuild < 20211) // Before Build 20211 Fe

--- a/src/GetVmIdWsl2.cpp
+++ b/src/GetVmIdWsl2.cpp
@@ -39,7 +39,7 @@ bool GetCommandLineForPID(DWORD pid, std::wstring& commandLine)
     if (process == NULL)
     {
         DWORD err = GetLastError();
-        fatal("failed to open the process, error: %d", err);
+        //fatal("failed to open the process, error: %d", err);
         return false;
     }
     // Get the address of the PEB

--- a/src/wslbridge2-backend.cpp
+++ b/src/wslbridge2-backend.cpp
@@ -132,7 +132,13 @@ int main(int argc, char *argv[])
     }
 
     if (xtraMode)
+    {
+        char buf[2];
+        printf("\n");
+        fflush(stdout);
+        fgets(buf, sizeof(buf), stdin);
         return 0;
+    }
 
     /* If size not provided use master window size */
     if (winp.ws_col == 0 || winp.ws_row == 0)


### PR DESCRIPTION
When wslhost.exe is running with administrator privileges, it cannot retrieve its own command line arguments. Therefore, we will obtain the command line arguments of the newly launched wslhost.exe while wslbridge2-backend is running.

fixes mintty/wsltty#363